### PR TITLE
Fix syntax issue in telegram_client response formatting

### DIFF
--- a/telegram_client.py
+++ b/telegram_client.py
@@ -68,9 +68,10 @@ class TelegramClient:
             if reply_to_message is not None:
                 message_parameters.update({'reply_to_message_id': reply_to_message})
             message_parameters.update({
-                'text':
-                    f'{message_parameters['text']}\n\n'
-                    f'DEBUG INFO: <i>{response.get('content', {}).get('debug')}</i>'
+                'text': (
+                    f"{message_parameters['text']}\n\n"
+                    f"DEBUG INFO: <i>{response.get('content', {}).get('debug')}</i>"
+                )
             })
             await update.effective_chat.send_message(**message_parameters)
             if (winner := response.get('content', {}).get('winner')) is not None:


### PR DESCRIPTION
## Summary
- fix f-string quoting in `process_responses` to avoid syntax errors

## Testing
- `python -m py_compile config.py conversation.py interlocutor.py main.py build_system_prompt.py telegram_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6845798a6c54832882d8f6c1b27ad0cb